### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/POC/admin-grails/pom.xml
+++ b/POC/admin-grails/pom.xml
@@ -227,7 +227,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     
     <dependency>

--- a/POC/atma/pom.xml
+++ b/POC/atma/pom.xml
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jdom</groupId>

--- a/POC/zip-streaming/pom.xml
+++ b/POC/zip-streaming/pom.xml
@@ -23,7 +23,7 @@
 	<commons.codec.version>1.6</commons.codec.version>
 	<commons.schema.version>1.4.7</commons.schema.version>
     <commons.beanutils.version>1.8.3</commons.beanutils.version>
-    <commons.collections.version>3.2.1</commons.collections.version>
+    <commons.collections.version>3.2.2</commons.collections.version>
   </properties>
 
 	<repositories>

--- a/sli/pom.xml
+++ b/sli/pom.xml
@@ -144,7 +144,7 @@
         <avro.version>1.6.1</avro.version>
         <commons.beanutils.version>1.8.3</commons.beanutils.version>
         <commons.codec.version>1.6</commons.codec.version>
-        <commons.collections.version>3.2.1</commons.collections.version>
+        <commons.collections.version>3.2.2</commons.collections.version>
         <commons.compression.version>1.8.1</commons.compression.version>
         <commons.cli.version>1.2</commons.cli.version>
         <commons.dbcp.version>20030825.184428</commons.dbcp.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
